### PR TITLE
refactor: handle response error message with unified logic

### DIFF
--- a/portal/portal.go
+++ b/portal/portal.go
@@ -158,7 +158,7 @@ func (cr *commonRsp) Err() error {
 	if cr.Status == "ok" {
 		// if suc_msg is not login_ok, warn
 		if cr.SuccessMsg != "" && cr.SuccessMsg != "login_ok" {
-			logrus.Warnln(cr.SuccessMsg)
+			logrus.Warnln("server response:", cr.SuccessMsg)
 		}
 		return nil
 	}

--- a/portal/portal.go
+++ b/portal/portal.go
@@ -124,8 +124,8 @@ func ResolveLocalClientIP() (string, error) {
 	return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
 }
 
-// CommonRsp struct for login session specific response
-type CommonRsp struct {
+// commonRsp struct for login session specific response
+type commonRsp struct {
 	// return code and various messages
 	// trash, but we have to add it
 	Status     string `json:"error"`
@@ -141,8 +141,8 @@ type CommonRsp struct {
 	Challenge  string `json:"challenge"`
 }
 
-// Error implements the error interface for CommonRsp
-func (cr *CommonRsp) Error() string {
+// Error implements the error interface for commonRsp
+func (cr *commonRsp) Error() string {
 	// handle error msg and code based on priority
 	if cr.PloyMsg != "" {
 		return cr.PloyMsg
@@ -158,7 +158,7 @@ func (cr *CommonRsp) Error() string {
 }
 
 // Err checks if the response indicates an error
-func (cr *CommonRsp) Err() error {
+func (cr *commonRsp) Err() error {
 	if cr.Status == "ok" {
 		// if suc_msg is not login_ok, warn
 		if cr.SuccessMsg != "" && cr.SuccessMsg != "login_ok" {
@@ -221,7 +221,7 @@ func (p *Portal) GetChallenge() (string, error) {
 		return "", ErrUnexpectedChallengeResponse
 	}
 
-	var r CommonRsp
+	var r commonRsp
 	err = json.Unmarshal(data[11:len(data)-1], &r)
 	if err != nil {
 		return "", err
@@ -297,7 +297,7 @@ func (p *Portal) Login(challenge string) error {
 		return ErrUnexpectedLoginResponse
 	}
 
-	var r CommonRsp
+	var r commonRsp
 	err = json.Unmarshal(data[11:len(data)-1], &r)
 	if err != nil {
 		return err

--- a/portal/portal.go
+++ b/portal/portal.go
@@ -153,8 +153,8 @@ func (cr *commonRsp) Error() string {
 	return cr.Status
 }
 
-// Err checks if the response indicates an error
-func (cr *commonRsp) Err() error {
+// err checks if the response indicates an error
+func (cr *commonRsp) err() error {
 	if cr.Status == "ok" {
 		// if suc_msg is not login_ok, warn
 		if cr.SuccessMsg != "" && cr.SuccessMsg != "login_ok" {
@@ -222,7 +222,7 @@ func (p *Portal) GetChallenge() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = r.Err()
+	err = r.err()
 	// rsp message handling
 	if err != nil {
 		return "", err
@@ -305,5 +305,5 @@ func (p *Portal) Login(challenge string) error {
 		logrus.Warnf("request: %s, response: %s", p.cip, r.ClientIP)
 	}
 
-	return r.Err()
+	return r.err()
 }

--- a/portal/portal.go
+++ b/portal/portal.go
@@ -150,11 +150,7 @@ func (cr *commonRsp) Error() string {
 	if cr.ErrorMsg != "" {
 		return cr.ErrorMsg
 	}
-	if cr.Status != "" && cr.Status != "ok" {
-		return cr.Status
-	}
-	// fallback
-	return "unknown portal response error"
+	return cr.Status
 }
 
 // Err checks if the response indicates an error


### PR DESCRIPTION
- since some detailed messages may not be shown in `error`, we refactor `rsp` struct to cover all message types from server.